### PR TITLE
[codex] Update next-mdx-remote security dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "he": "^1.2.0",
     "lucide-react": "^0.562.0",
     "next": "16.2.6",
-    "next-mdx-remote": "^5.0.0",
+    "next-mdx-remote": "6.0.0",
     "next-safe-action": "^8.0.11",
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.9.17",


### PR DESCRIPTION
## Summary

- Updates `next-mdx-remote` from the vulnerable 5.x range to patched `6.0.0`.
- Addresses Dependabot alert GHSA-g4xw-jxrg-5f6m / CVE-2026-0969.

## Validation

- `yarn why next-mdx-remote --ignore-engines`
- `yarn lint`

## Notes

`yarn.lock` is ignored by this repository, so the tracked fix is limited to `package.json`. Local install validation confirms `next-mdx-remote@6.0.0` resolves successfully.