### PR TITLE
Secure community project ingestion

### DIFF
--- a/docs/security/community-projects-rollout.md
+++ b/docs/security/community-projects-rollout.md
@@ -1,0 +1,73 @@
+# Community projects security rollout
+
+The registry and website changes must be deployed in this order. Do not enable
+the final CSP until production is serving the source-controlled report-only
+header without violations.
+
+## 1. Merge and publish the registry
+
+1. Merge the `Meyse/verus-projects` hardening changes.
+2. In **Settings → Actions → General**, set the default workflow token to
+   read-only and require approval for workflows from outside contributors.
+3. Protect `main` with pull requests, the up-to-date `validate` check, resolved
+   conversations, blocked force pushes/deletion, and administrator enforcement.
+   Keep required approvals at zero while `@Meyse` is the sole reviewer.
+4. In the `github-pages` environment, allow deployments only from `main` and
+   disable administrator bypass.
+5. Enable the `Publish registry` workflow if GitHub still reports it as disabled
+   due to inactivity. Run it manually once and confirm Pages contains only
+   `projects.json`, the schema, and sanitized PNG/JPEG/WebP assets.
+6. Run `Refresh registry metadata` manually once. A future inactivity disablement
+   of this scheduled workflow must not disable `Publish registry`.
+
+## 2. Deploy the website to nextdev in report-only mode
+
+1. Deploy the website revision to `nextdev.verus.io` using a production build.
+   The report-only header is intentionally not emitted by `next dev`.
+2. Confirm nextdev returns exactly one report-only policy and no enforced CSP
+   header:
+
+   ```bash
+   curl -sS -I https://nextdev.verus.io/projects
+   ```
+
+3. Exercise `/projects`, at least one `/projects/[slug]` page, `/projects/add`,
+   search/filter controls, the YAML download, and `/api/projects.json` in a real
+   browser. Investigate every `securitypolicyviolation` or CSP console message.
+   Add only an exact source required by confirmed site functionality.
+
+## 3. Promote the report-only website to production
+
+1. On the production host, run `nginx -T` and locate every directive that sets,
+   hides, or replaces `Content-Security-Policy`.
+2. Remove the malformed nginx CSP override. Keep the existing HSTS,
+   `X-Frame-Options`, `X-Content-Type-Options`, and referrer headers.
+3. Run `nginx -t` before reloading nginx.
+4. Deploy the same website revision tested on nextdev.
+5. Confirm production returns exactly one report-only policy and no enforced
+   CSP header:
+
+   ```bash
+   curl -sS -I https://verus.io/projects
+   ```
+
+6. Repeat the nextdev browser checks against production before enforcing the
+   policy.
+
+## 4. Enforce the CSP
+
+After a clean production crawl, change the header name in `next.config.ts` from
+`Content-Security-Policy-Report-Only` to `Content-Security-Policy` and add
+`upgrade-insecure-requests` to the policy directives. Deploy, repeat the browser
+crawl, and confirm production returns exactly one enforced CSP header.
+
+If enforcement breaks a confirmed feature, revert the header name to report-only
+while the exact missing source is investigated. Do not add broad script origins
+or remove `script-src-attr 'none'`, `frame-ancestors 'none'`, or
+`object-src 'none'` as a quick workaround.
+
+## 5. Account recovery
+
+Verify the `Meyse` GitHub account has two-factor authentication, a passkey or
+hardware security key, and an offline recovery method. Never place recovery
+codes, tokens, or screenshots of account-security settings in either repository.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type {NextConfig} from 'next'
 
+import {CONTENT_SECURITY_POLICY} from '@/configs/content-security-policy'
 import {env} from '@/configs/env'
 
 const _env = env
@@ -35,6 +36,22 @@ const nextConfig: NextConfig = {
     serverActions: {
       allowedOrigins: ['verus.io', '*.verus.io'],
     },
+  },
+
+  async headers() {
+    if (_env.NODE_ENV !== 'production') return []
+
+    return [
+      {
+        headers: [
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: `${CONTENT_SECURITY_POLICY};`,
+          },
+        ],
+        source: '/:path*',
+      },
+    ]
   },
 
   async redirects() {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "private": true,
   "packageManager": "pnpm@10.29.2",
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "unrs-resolver"
+    ],
     "overrides": {
       "postcss": "8.5.25"
     }
@@ -21,6 +25,7 @@
     "format": "prettier --write . ",
     "format:check": "prettier --check . ",
     "lint": "eslint .",
+    "test:projects-security": "tsx --test src/features/projects/project-markdown.test.tsx src/features/projects/server/registry.test.ts",
     "test:verusid-cache": "node scripts/check-verusid-cache-contract.js"
   },
   "dependencies": {
@@ -77,6 +82,7 @@
     "prettier": "^3.7.4",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^3.4.17",
+    "tsx": "4.23.11",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.51.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 3.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.19(yaml@2.8.4))
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.11)(yaml@2.8.4))
       web3:
         specifier: ^4.16.0
         version: 4.16.0(typescript@5.9.3)(zod@4.4.3)
@@ -164,7 +164,10 @@ importers:
         version: 0.6.14(@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3))(prettier@3.8.3)
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(yaml@2.8.4)
+        version: 3.4.19(tsx@4.23.11)(yaml@2.8.4)
+      tsx:
+        specifier: 4.23.11
+        version: 4.23.11
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -296,6 +299,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -1826,6 +1985,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3277,6 +3441,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.11:
+    resolution: {integrity: sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3721,6 +3890,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.2(jiti@1.21.7))':
@@ -5230,6 +5477,35 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6522,12 +6798,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.25
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.25)(yaml@2.8.4):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.25)(tsx@4.23.11)(yaml@2.8.4):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.25
+      tsx: 4.23.11
       yaml: 2.8.4
 
   postcss-nested@6.2.0(postcss@8.5.25):
@@ -6995,11 +7272,11 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(yaml@2.8.4)):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.23.11)(yaml@2.8.4)):
     dependencies:
-      tailwindcss: 3.4.19(yaml@2.8.4)
+      tailwindcss: 3.4.19(tsx@4.23.11)(yaml@2.8.4)
 
-  tailwindcss@3.4.19(yaml@2.8.4):
+  tailwindcss@3.4.19(tsx@4.23.11)(yaml@2.8.4):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -7018,7 +7295,7 @@ snapshots:
       postcss: 8.5.25
       postcss-import: 15.1.0(postcss@8.5.25)
       postcss-js: 4.1.0(postcss@8.5.25)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.25)(yaml@2.8.4)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.25)(tsx@4.23.11)(yaml@2.8.4)
       postcss-nested: 6.2.0(postcss@8.5.25)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -7069,6 +7346,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.23.11:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/src/app/projects/add/page.tsx
+++ b/src/app/projects/add/page.tsx
@@ -21,7 +21,9 @@ const yamlTemplate = `name: "Your project name"
 slug: "your-project-slug"
 description: "Short one-line description"
 longDescription: |
-  Describe what the project does and how it uses Verus. Markdown is supported.
+  Describe what the project does and how it uses Verus. Text formatting such as
+  headings, lists and emphasis is supported. Links and embedded images are not
+  rendered; use the reviewed URL fields below instead.
 
   ## Features
 
@@ -52,7 +54,10 @@ verusFeatures:
 # rotation on verus.io.
 # - logo.png/logo.jpg/logo.webp: 128x128px square
 # - featured.png/featured.jpg/featured.webp: 800x300px, 8:3 aspect ratio
-# - screenshot1.png through screenshot6.png: aim for at least 1200px on the longest edge`
+# - screenshot1.png through screenshot6.png: aim for at least 1200px on the longest edge
+# Images must be PNG, JPEG or WebP; each file is limited to 5 MiB, 40 megapixels
+# and 8192px on either edge. Published images are decoded, stripped of metadata
+# and re-encoded during registry publication.`
 
 export default function AddProjectPage() {
   return (
@@ -129,7 +134,8 @@ export default function AddProjectPage() {
                       </h3>
                       <p className="mt-2 max-w-2xl text-[15px] leading-relaxed tracking-normal text-gray-600 dark:text-gray-300 md:text-[17px]">
                         Put images next to the YAML file in the project folder.
-                        PNG, JPG, and WebP are supported.
+                        PNG, JPG, and WebP are supported. Each image is limited
+                        to 5 MiB and is sanitized before publication.
                       </p>
                       <div className="mt-3 overflow-x-auto">
                         <code className="inline-flex max-w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-[14px] text-gray-800 dark:border-gray-800 dark:bg-gray-900 dark:text-white">

--- a/src/configs/content-security-policy.ts
+++ b/src/configs/content-security-policy.ts
@@ -1,0 +1,17 @@
+export const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "script-src-attr 'none'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "media-src 'self'",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+].join('; ')

--- a/src/features/projects/project-markdown.test.tsx
+++ b/src/features/projects/project-markdown.test.tsx
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {renderToStaticMarkup} from 'react-dom/server'
+
+import {ProjectMarkdown} from './project-markdown'
+
+void test('renders the approved project Markdown formatting subset', () => {
+  const html = renderToStaticMarkup(
+    <ProjectMarkdown>{`## Heading
+
+**Bold** and *emphasized* text.
+
+1. First
+2. Second
+
+> Quoted text
+
+\`inline code\``}</ProjectMarkdown>
+  )
+
+  assert.match(html, /<h2/)
+  assert.match(html, /<strong>Bold<\/strong>/)
+  assert.match(html, /<em>emphasized<\/em>/)
+  assert.match(html, /<ol/)
+  assert.match(html, /<blockquote/)
+  assert.match(html, /<code>inline code<\/code>/)
+})
+
+void test('removes active links, remote images, and raw HTML', () => {
+  const html = renderToStaticMarkup(
+    <ProjectMarkdown>{`[Reviewed-looking link](https://attacker.example/phish)
+
+[Script link](javascript:alert(1))
+
+![Tracking image](https://attacker.example/pixel.png)
+
+<script>alert(1)</script>
+
+<img src="https://attacker.example/raw.png" onerror="alert(1)">
+
+<a href="https://attacker.example">Raw link</a>`}</ProjectMarkdown>
+  )
+
+  assert.doesNotMatch(html, /<a\b/i)
+  assert.doesNotMatch(html, /<img\b/i)
+  assert.doesNotMatch(html, /<script\b/i)
+  assert.doesNotMatch(html, /href=/i)
+  assert.doesNotMatch(html, /src=/i)
+  assert.doesNotMatch(html, /onerror=/i)
+  assert.doesNotMatch(html, /attacker\.example/i)
+  assert.match(html, /Reviewed-looking link/)
+  assert.match(html, /Script link/)
+})

--- a/src/features/projects/project-markdown.tsx
+++ b/src/features/projects/project-markdown.tsx
@@ -1,10 +1,33 @@
 import Markdown from 'react-markdown'
 import rehypeSanitize from 'rehype-sanitize'
 
+export const PROJECT_MARKDOWN_ALLOWED_ELEMENTS = [
+  'blockquote',
+  'br',
+  'code',
+  'del',
+  'em',
+  'h2',
+  'h3',
+  'hr',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'strong',
+  'ul',
+]
+
 export function ProjectMarkdown({children}: {children: string}) {
   return (
     <Markdown
+      allowedElements={PROJECT_MARKDOWN_ALLOWED_ELEMENTS}
       components={{
+        blockquote: ({children}) => (
+          <blockquote className="mb-5 border-l-2 border-gray-300 pl-4 text-gray-600 dark:border-gray-700 dark:text-gray-300">
+            {children}
+          </blockquote>
+        ),
         h2: ({children}) => (
           <h2 className="mb-3 mt-8 text-[22px] font-medium leading-[1.2] tracking-tight text-gray-800 first:mt-0 dark:text-white md:text-[26px]">
             {children}
@@ -20,6 +43,9 @@ export function ProjectMarkdown({children}: {children: string}) {
             {children}
           </li>
         ),
+        ol: ({children}) => (
+          <ol className="mb-5 list-decimal space-y-2 pl-5">{children}</ol>
+        ),
         p: ({children}) => (
           <p className="mb-4 text-[15px] leading-relaxed tracking-normal text-gray-600 dark:text-gray-300 md:text-[17px]">
             {children}
@@ -30,9 +56,10 @@ export function ProjectMarkdown({children}: {children: string}) {
         ),
       }}
       rehypePlugins={[rehypeSanitize]}
+      skipHtml
+      unwrapDisallowed
     >
       {children}
     </Markdown>
   )
 }
-

--- a/src/features/projects/server/projects.ts
+++ b/src/features/projects/server/projects.ts
@@ -2,128 +2,33 @@ import 'server-only'
 
 import type {Project, ProjectCategory} from '../types'
 
-import {
-  validateProjectAssetFilename,
-  validateProjectAssetPath,
-} from '../asset-validation'
-import {ProjectYAMLSchema, validateSlug} from '../validation'
+import {validateSlug} from '../validation'
 import {PROJECTS_REGISTRY_URL} from './config'
+import {normalizeRegistryPayload, readBoundedRegistryJson} from './registry'
 
 const REGISTRY_REVALIDATE_SECONDS = 86400
+const REGISTRY_FETCH_TIMEOUT_MS = 10_000
 const FEATURED_ELIGIBLE_CATEGORIES: ProjectCategory[] = [
   'app',
   'dashboard',
   'wallet',
 ]
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-}
-
-function getOptionalString(value: unknown) {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
-}
-
-function resolveRegistryAssetBaseUrl(
-  registryUrl: string,
-  project: Project,
-  assetPath: unknown
-) {
-  const safeAssetPath = validateProjectAssetPath(
-    getOptionalString(assetPath),
-    project.slug
-  )
-  if (!safeAssetPath) return undefined
-
-  return new URL(`${safeAssetPath}/`, registryUrl).toString().replace(/\/$/, '')
-}
-
-function normalizeRegistryProject(
-  item: unknown,
-  registryUrl: string
-): Project | null {
-  if (!isRecord(item)) return null
-
-  const parsed = ProjectYAMLSchema.safeParse(item)
-  if (!parsed.success) return null
-
-  const github = isRecord(item.github)
-    ? {
-        forks: typeof item.github.forks === 'number' ? item.github.forks : 0,
-        languages: Array.isArray(item.github.languages)
-          ? item.github.languages.filter(
-              (language): language is string => typeof language === 'string'
-            )
-          : [],
-        lastCommit:
-          typeof item.github.lastCommit === 'string'
-            ? item.github.lastCommit
-            : '',
-        license:
-          typeof item.github.license === 'string' ? item.github.license : null,
-        stars: typeof item.github.stars === 'number' ? item.github.stars : 0,
-      }
-    : null
-
-  const featuredImage = validateProjectAssetFilename(
-    getOptionalString(item.featuredImage),
-    'featured'
-  )
-  const logo = validateProjectAssetFilename(getOptionalString(item.logo), 'logo')
-  const screenshots = Array.isArray(item.screenshots)
-    ? item.screenshots
-        .map((screenshot) =>
-          validateProjectAssetFilename(
-            getOptionalString(screenshot),
-            'screenshot'
-          )
-        )
-        .filter((screenshot): screenshot is string => screenshot !== null)
-    : []
-
-  const project: Project = {
-    ...parsed.data,
-    featuredImage,
-    github,
-    logo: logo || undefined,
-    maintainer: parsed.data.maintainer || 'Verus community',
-    screenshots,
-  }
-
-  return {
-    ...project,
-    assetBaseUrl: resolveRegistryAssetBaseUrl(
-      registryUrl,
-      project,
-      item.assetPath
-    ),
-  }
-}
-
 async function fetchRegistryProjects() {
   try {
     const response = await fetch(PROJECTS_REGISTRY_URL, {
       next: {revalidate: REGISTRY_REVALIDATE_SECONDS},
+      signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
     })
 
     if (!response.ok) {
       throw new Error(`Registry request failed with ${response.status}`)
     }
 
-    const registry = await response.json()
-
-    if (!isRecord(registry) || !Array.isArray(registry.projects)) {
-      throw new Error('Registry response is missing projects array')
-    }
-
-    const projects = registry.projects
-      .map((project) =>
-        normalizeRegistryProject(project, PROJECTS_REGISTRY_URL)
-      )
-      .filter((project): project is Project => project !== null)
-      .sort((a, b) => a.name.localeCompare(b.name))
-
-    return projects
+    return normalizeRegistryPayload(
+      await readBoundedRegistryJson(response),
+      PROJECTS_REGISTRY_URL
+    )
   } catch (error) {
     console.error(
       'Failed to load remote projects registry:',

--- a/src/features/projects/server/registry.test.ts
+++ b/src/features/projects/server/registry.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {CONTENT_SECURITY_POLICY} from '@/configs/content-security-policy'
+
+import {
+  normalizeRegistryPayload,
+  PROJECTS_REGISTRY_MAX_PROJECTS,
+  readBoundedRegistryJson,
+} from './registry'
+
+const registryUrl = 'https://meyse.github.io/verus-projects/projects.json'
+
+function project(overrides: Record<string, unknown> = {}) {
+  return {
+    assetPath: 'projects/safe-project',
+    category: 'app',
+    description: 'A safe project',
+    featuredImage: null,
+    github: null,
+    logo: null,
+    longDescription: 'Safe project text',
+    maintainer: 'Safe maintainer',
+    name: 'Safe project',
+    screenshots: [],
+    slug: 'safe-project',
+    verusFeatures: ['VerusID'],
+    ...overrides,
+  }
+}
+
+function envelope(projects: unknown[] = [project()]) {
+  return {
+    generatedAt: '2026-08-08T12:00:00.000Z',
+    projects,
+    schemaVersion: 1,
+  }
+}
+
+void test('normalizes a valid bounded registry', () => {
+  const projects = normalizeRegistryPayload(envelope(), registryUrl)
+  assert.equal(projects.length, 1)
+  assert.equal(
+    projects[0]?.assetBaseUrl,
+    'https://meyse.github.io/verus-projects/projects/safe-project'
+  )
+})
+
+void test('drops invalid records without trusting generated fields', () => {
+  const projects = normalizeRegistryPayload(
+    envelope([
+      project(),
+      project({assetPath: '../outside', slug: 'bad-path'}),
+      project({name: 'Unknown field', slug: 'unknown', unexpected: true}),
+      project({github: {forks: -1}}),
+    ]),
+    registryUrl
+  )
+  assert.deepEqual(
+    projects.map(({slug}) => slug),
+    ['safe-project']
+  )
+})
+
+void test('rejects duplicate slugs and invalid envelopes', () => {
+  assert.throws(
+    () =>
+      normalizeRegistryPayload(envelope([project(), project()]), registryUrl),
+    /duplicate slug/
+  )
+  assert.throws(
+    () =>
+      normalizeRegistryPayload({...envelope(), schemaVersion: 2}, registryUrl),
+    /schemaVersion/
+  )
+  assert.throws(
+    () =>
+      normalizeRegistryPayload(
+        envelope(
+          Array.from({length: PROJECTS_REGISTRY_MAX_PROJECTS + 1}, (_, index) =>
+            project({
+              slug: `project-${index}`,
+              assetPath: `projects/project-${index}`,
+            })
+          )
+        ),
+        registryUrl
+      ),
+    /Too big/
+  )
+})
+
+void test('bounds registry response bytes using headers and streamed data', async () => {
+  await assert.rejects(
+    readBoundedRegistryJson(
+      new Response('{}', {headers: {'content-length': '100'}}),
+      10
+    ),
+    /exceeds 10 bytes/
+  )
+  await assert.rejects(
+    readBoundedRegistryJson(new Response('123456'), 5),
+    /exceeds 5 bytes/
+  )
+
+  const parsed = await readBoundedRegistryJson(
+    new Response(JSON.stringify(envelope())),
+    4096
+  )
+  assert.deepEqual(parsed, envelope())
+})
+
+void test('CSP blocks external scripts, frames, objects, and event handlers', () => {
+  assert.match(CONTENT_SECURITY_POLICY, /default-src 'self'/)
+  assert.match(CONTENT_SECURITY_POLICY, /script-src 'self' 'unsafe-inline'/)
+  assert.match(CONTENT_SECURITY_POLICY, /script-src-attr 'none'/)
+  assert.match(CONTENT_SECURITY_POLICY, /frame-ancestors 'none'/)
+  assert.match(CONTENT_SECURITY_POLICY, /frame-src 'none'/)
+  assert.match(CONTENT_SECURITY_POLICY, /object-src 'none'/)
+  assert.doesNotMatch(CONTENT_SECURITY_POLICY, /script-src[^;]*https:/)
+})

--- a/src/features/projects/server/registry.ts
+++ b/src/features/projects/server/registry.ts
@@ -1,0 +1,169 @@
+import type {Project} from '../types'
+
+import {z} from 'zod'
+
+import {
+  validateProjectAssetFilename,
+  validateProjectAssetPath,
+} from '../asset-validation'
+import {ProjectYAMLSchema} from '../validation'
+
+export const PROJECTS_REGISTRY_MAX_BYTES = 4 * 1024 * 1024
+export const PROJECTS_REGISTRY_MAX_PROJECTS = 250
+
+const GithubDataSchema = z
+  .object({
+    forks: z.number().int().min(0).max(1_000_000_000),
+    languages: z
+      .array(z.string().min(1).max(64))
+      .max(50)
+      .refine((languages) => new Set(languages).size === languages.length),
+    lastCommit: z
+      .string()
+      .max(64)
+      .refine(
+        (value) => value === '' || Number.isFinite(Date.parse(value)),
+        'Invalid last commit timestamp'
+      ),
+    license: z.string().max(128).nullable(),
+    stars: z.number().int().min(0).max(1_000_000_000),
+  })
+  .strict()
+
+const RegistryEnvelopeSchema = z
+  .object({
+    generatedAt: z
+      .string()
+      .max(64)
+      .refine(
+        (value) => Number.isFinite(Date.parse(value)),
+        'Invalid registry timestamp'
+      ),
+    projects: z.array(z.unknown()).max(PROJECTS_REGISTRY_MAX_PROJECTS),
+    schemaVersion: z.literal(1),
+  })
+  .strict()
+
+const RegistryProjectSchema = ProjectYAMLSchema.extend({
+  assetPath: z.string().max(128),
+  featuredImage: z.string().max(100).nullable().optional(),
+  github: GithubDataSchema.nullable(),
+  logo: z.string().max(100).nullable().optional(),
+}).strict()
+
+function resolveRegistryAssetBaseUrl(
+  registryUrl: string,
+  project: Project,
+  assetPath: string
+) {
+  const safeAssetPath = validateProjectAssetPath(assetPath, project.slug)
+  if (!safeAssetPath) return null
+
+  const registry = new URL(registryUrl)
+  const assetBaseUrl = new URL(`${safeAssetPath}/`, registry)
+  if (
+    registry.protocol !== 'https:' ||
+    assetBaseUrl.protocol !== 'https:' ||
+    assetBaseUrl.origin !== registry.origin
+  ) {
+    return null
+  }
+
+  return assetBaseUrl.toString().replace(/\/$/, '')
+}
+
+function normalizeRegistryProject(
+  value: unknown,
+  registryUrl: string
+): Project | null {
+  const parsed = RegistryProjectSchema.safeParse(value)
+  if (!parsed.success) return null
+
+  const featuredImage = validateProjectAssetFilename(
+    parsed.data.featuredImage,
+    'featured'
+  )
+  const logo = validateProjectAssetFilename(parsed.data.logo, 'logo')
+  const screenshots = (parsed.data.screenshots || [])
+    .map((filename) => validateProjectAssetFilename(filename, 'screenshot'))
+    .filter((filename): filename is string => filename !== null)
+
+  if (
+    (parsed.data.featuredImage && !featuredImage) ||
+    (parsed.data.logo && !logo) ||
+    screenshots.length !== (parsed.data.screenshots || []).length
+  ) {
+    return null
+  }
+
+  const {assetPath, ...projectData} = parsed.data
+  const project: Project = {
+    ...projectData,
+    featuredImage,
+    logo: logo || undefined,
+    maintainer: parsed.data.maintainer || 'Verus community',
+    screenshots,
+  }
+  const assetBaseUrl = resolveRegistryAssetBaseUrl(
+    registryUrl,
+    project,
+    assetPath
+  )
+  if (!assetBaseUrl) return null
+
+  return {...project, assetBaseUrl}
+}
+
+export function normalizeRegistryPayload(
+  value: unknown,
+  registryUrl: string
+): Project[] {
+  const envelope = RegistryEnvelopeSchema.parse(value)
+  const projects = envelope.projects
+    .map((project) => normalizeRegistryProject(project, registryUrl))
+    .filter((project): project is Project => project !== null)
+  const seenSlugs = new Set<string>()
+
+  for (const project of projects) {
+    if (seenSlugs.has(project.slug)) {
+      throw new Error(`Registry contains duplicate slug: ${project.slug}`)
+    }
+    seenSlugs.add(project.slug)
+  }
+
+  return projects.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export async function readBoundedRegistryJson(
+  response: Response,
+  maximumBytes = PROJECTS_REGISTRY_MAX_BYTES
+) {
+  const declaredLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > maximumBytes) {
+    throw new Error(`Registry response exceeds ${maximumBytes} bytes`)
+  }
+  if (!response.body) throw new Error('Registry response body is missing')
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder('utf-8', {fatal: true})
+  let text = ''
+  let totalBytes = 0
+
+  try {
+    while (true) {
+      const {done, value} = await reader.read()
+      if (done) break
+      totalBytes += value.byteLength
+      if (totalBytes > maximumBytes) {
+        await reader.cancel()
+        throw new Error(`Registry response exceeds ${maximumBytes} bytes`)
+      }
+      text += decoder.decode(value, {stream: true})
+    }
+    text += decoder.decode()
+  } finally {
+    reader.releaseLock()
+  }
+
+  return JSON.parse(text) as unknown
+}

--- a/src/features/projects/validation.ts
+++ b/src/features/projects/validation.ts
@@ -6,6 +6,8 @@ import {
 } from './asset-validation'
 import {PROJECT_CATEGORIES, VERUS_FEATURES} from './types'
 
+export const PROJECT_URL_MAX_LENGTH = 2048
+
 const allowedProtocols = ['https:']
 const blockedUrlPatterns = [
   /^javascript:/i,
@@ -18,7 +20,7 @@ export function validateExternalUrl(url: string | undefined | null) {
   if (!url) return null
 
   const trimmed = url.trim()
-  if (!trimmed) return null
+  if (!trimmed || trimmed.length > PROJECT_URL_MAX_LENGTH) return null
 
   if (blockedUrlPatterns.some((pattern) => pattern.test(trimmed))) {
     return null
@@ -27,7 +29,13 @@ export function validateExternalUrl(url: string | undefined | null) {
   try {
     const parsed = new URL(trimmed)
 
-    if (!allowedProtocols.includes(parsed.protocol) || !parsed.hostname) {
+    if (
+      !allowedProtocols.includes(parsed.protocol) ||
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password ||
+      parsed.port
+    ) {
       return null
     }
 
@@ -47,7 +55,12 @@ export function validateGitHubUrl(url: string | undefined | null) {
     const isGithubHost =
       parsed.hostname === 'github.com' || parsed.hostname === 'www.github.com'
 
-    if (!isGithubHost || pathParts.length < 2) {
+    if (
+      !isGithubHost ||
+      pathParts.length !== 2 ||
+      parsed.search ||
+      parsed.hash
+    ) {
       return null
     }
 
@@ -59,62 +72,74 @@ export function validateGitHubUrl(url: string | undefined | null) {
 
 const SafeUrlSchema = z
   .string()
+  .trim()
+  .max(PROJECT_URL_MAX_LENGTH, 'URL is too long')
   .refine((url) => validateExternalUrl(url) !== null, {
     message: 'Invalid or unsafe URL',
   })
 
 const GitHubUrlSchema = z
   .string()
+  .trim()
+  .max(PROJECT_URL_MAX_LENGTH, 'URL is too long')
   .refine((url) => validateGitHubUrl(url) !== null, {
     message: 'Invalid GitHub repository URL',
   })
 
-export const ProjectYAMLSchema = z.object({
-  category: z.enum(PROJECT_CATEGORIES),
-  description: z
-    .string()
-    .min(1, 'Description is required')
-    .max(220, 'Description must be 220 characters or less'),
-  docsUrl: SafeUrlSchema.optional(),
-  longDescription: z
-    .string()
-    .min(1, 'Long description is required')
-    .max(10000, 'Long description must be 10000 characters or less'),
-  maintainer: z
-    .string()
-    .max(100, 'Maintainer must be 100 characters or less')
-    .optional(),
-  name: z
-    .string()
-    .min(1, 'Name is required')
-    .max(80, 'Name must be 80 characters or less'),
-  repoUrl: GitHubUrlSchema.optional(),
-  screenshots: z
-    .array(
-      z
-        .string()
-        .max(100, 'Screenshot filename must be 100 characters or less')
-        .refine(
-          (filename) =>
-            validateProjectAssetFilename(filename, 'screenshot') !== null,
-          {
-            message: 'Invalid screenshot filename',
-          }
-        )
-    )
-    .max(6, 'Maximum 6 screenshots allowed')
-    .optional(),
-  slug: z
-    .string()
-    .min(1, 'Slug is required')
-    .max(60, 'Slug must be 60 characters or less')
-    .regex(
-      PROJECT_SLUG_PATTERN,
-      'Slug must be lowercase alphanumeric with hyphens'
-    ),
-  verusFeatures: z.array(z.enum(VERUS_FEATURES)).min(1),
-  websiteUrl: SafeUrlSchema.optional(),
-})
+export const ProjectYAMLSchema = z
+  .object({
+    category: z.enum(PROJECT_CATEGORIES),
+    description: z
+      .string()
+      .min(1, 'Description is required')
+      .max(220, 'Description must be 220 characters or less'),
+    docsUrl: SafeUrlSchema.optional(),
+    longDescription: z
+      .string()
+      .min(1, 'Long description is required')
+      .max(10000, 'Long description must be 10000 characters or less'),
+    maintainer: z
+      .string()
+      .max(100, 'Maintainer must be 100 characters or less')
+      .optional(),
+    name: z
+      .string()
+      .min(1, 'Name is required')
+      .max(80, 'Name must be 80 characters or less'),
+    repoUrl: GitHubUrlSchema.optional(),
+    screenshots: z
+      .array(
+        z
+          .string()
+          .max(100, 'Screenshot filename must be 100 characters or less')
+          .refine(
+            (filename) =>
+              validateProjectAssetFilename(filename, 'screenshot') !== null,
+            {
+              message: 'Invalid screenshot filename',
+            }
+          )
+      )
+      .max(6, 'Maximum 6 screenshots allowed')
+      .optional(),
+    slug: z
+      .string()
+      .min(1, 'Slug is required')
+      .max(60, 'Slug must be 60 characters or less')
+      .regex(
+        PROJECT_SLUG_PATTERN,
+        'Slug must be lowercase alphanumeric with hyphens'
+      ),
+    verusFeatures: z
+      .array(z.enum(VERUS_FEATURES))
+      .min(1)
+      .max(VERUS_FEATURES.length)
+      .refine((features) => new Set(features).size === features.length, {
+        message: 'Features must be unique',
+      }),
+    websiteUrl: SafeUrlSchema.optional(),
+  })
+  .strict()
 
 export type ValidatedProjectYAML = z.infer<typeof ProjectYAMLSchema>
 


### PR DESCRIPTION
## Summary

- bound and validate the remote community-project registry before use
- constrain project Markdown to a sanitized, non-interactive formatting subset
- add a restrictive report-only Content Security Policy for staged verification
- document the nextdev-first production rollout and contributor limits
- add focused ingestion, rendering, and CSP regression tests

## Why

The website consumes a remotely published community registry. The consumer must remain safe even if an invalid or malicious registry artifact reaches that trust boundary.

## Verification

- `corepack pnpm test:projects-security` (7 tests)
- `corepack pnpm test:verusid-cache`
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec next build --webpack` (57 routes)
- `git diff --check`

The default Turbopack production build was also previously verified. In the final pre-publish rerun, its internal CSS worker could not bind a local port in the restricted execution environment; the supported webpack production build passed completely.
